### PR TITLE
Fix navigation fetch handling in service worker

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -44,7 +44,12 @@ self.addEventListener('fetch', (event) => {
 
 async function handleNavigationRequest(request) {
   try {
-    const networkResponse = await fetch(request, { redirect: 'follow' });
+    const networkResponse = await fetch(request.url, {
+      method: request.method,
+      headers: request.headers,
+      redirect: 'follow',
+      credentials: 'include',
+    });
 
     if (networkResponse?.type === 'opaqueredirect') {
       return fetch('/login', { redirect: 'follow' });


### PR DESCRIPTION
## Summary
- ensure the service worker reissues navigation fetches with redirect-following behaviour
- keep navigation requests authenticated by including credentials

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbdfe91130832ea8816c250999ed2f