### PR TITLE
Ensure NextAuth has a development secret fallback

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,7 +5,17 @@ import { compare } from 'bcryptjs';
 import { prisma } from './prisma';
 import { LOGIN_ROUTE } from './routes';
 
+const nextAuthSecret = process.env.NEXTAUTH_SECRET ??
+  (process.env.NODE_ENV !== 'production' ? 'insecure-development-secret' : undefined);
+
+if (!nextAuthSecret) {
+  throw new Error('NEXTAUTH_SECRET must be set in production environments.');
+}
+
+process.env.NEXTAUTH_SECRET = nextAuthSecret;
+
 export const authOptions: NextAuthOptions = {
+  secret: nextAuthSecret,
   session: {
     strategy: 'jwt',
   },


### PR DESCRIPTION
## Summary
- add a development-safe fallback secret for NextAuth when NEXTAUTH_SECRET is missing
- surface a clear error in production if the secret is not configured
- share the resolved secret with both NextAuth and middleware to keep sessions working

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbe7364f84832e9c9a151f15bdb491