### PR TITLE
Tighten role-based authentication flow

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -6,46 +6,52 @@ import { ADMIN_ROUTE, HOME_ROUTE, LOGIN_ROUTE, WORKER_ROUTE, getDashboardRouteFo
 export default withAuth(
   (req) => {
     const token = req.nextauth.token;
-
-    if (!token) {
-      return NextResponse.next();
-    }
-
     const pathname = req.nextUrl.pathname;
-    const role = typeof token.role === 'string' ? token.role : undefined;
+    const role = typeof token?.role === 'string' ? token.role : undefined;
     const dashboardRoute = getDashboardRouteForRole(role, '');
     const isAdmin = role === 'ADMIN';
     const isWorker = role === 'WORKER';
     const isInAdminSection = pathname === ADMIN_ROUTE || pathname.startsWith(`${ADMIN_ROUTE}/`);
     const isInWorkerSection = pathname === WORKER_ROUTE || pathname.startsWith(`${WORKER_ROUTE}/`);
+    const shouldDisableCache = isInAdminSection || isInWorkerSection;
+
+    const applyNoStore = <T extends NextResponse>(response: T) => {
+      if (shouldDisableCache) {
+        response.headers.set('Cache-Control', 'no-store, no-cache, must-revalidate');
+        response.headers.set('Pragma', 'no-cache');
+        response.headers.set('Expires', '0');
+      }
+
+      return response;
+    };
 
     if (pathname === LOGIN_ROUTE) {
       if (dashboardRoute) {
-        return NextResponse.redirect(new URL(dashboardRoute, req.url));
+        return applyNoStore(NextResponse.redirect(new URL(dashboardRoute, req.url)));
       }
 
-      return NextResponse.next();
+      return applyNoStore(NextResponse.next());
     }
 
     if (pathname === HOME_ROUTE) {
       if (dashboardRoute) {
-        return NextResponse.redirect(new URL(dashboardRoute, req.url));
+        return applyNoStore(NextResponse.redirect(new URL(dashboardRoute, req.url)));
       }
 
-      return NextResponse.next();
+      return applyNoStore(NextResponse.next());
     }
 
     if (isInAdminSection && !isAdmin) {
       const fallback = dashboardRoute || LOGIN_ROUTE;
-      return NextResponse.redirect(new URL(fallback, req.url));
+      return applyNoStore(NextResponse.redirect(new URL(fallback, req.url)));
     }
 
     if (isInWorkerSection && !isWorker) {
       const fallback = dashboardRoute || LOGIN_ROUTE;
-      return NextResponse.redirect(new URL(fallback, req.url));
+      return applyNoStore(NextResponse.redirect(new URL(fallback, req.url)));
     }
 
-    return NextResponse.next();
+    return applyNoStore(NextResponse.next());
   },
   {
     callbacks: {

--- a/src/app/(auth)/login/login-form.tsx
+++ b/src/app/(auth)/login/login-form.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { getSession, signIn } from 'next-auth/react';
-import { usePathname, useRouter } from 'next/navigation';
+import { signIn } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -11,7 +11,6 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { getDashboardRouteForRole } from '@/lib/routes';
 
 const schema = z.object({
   email: z.string().email(),
@@ -28,7 +27,6 @@ type LoginFormProps = {
 
 export function LoginForm({ defaultEmail = '', callbackUrl, initialError }: LoginFormProps) {
   const router = useRouter();
-  const pathname = usePathname();
   const [isSubmitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(initialError ?? null);
 
@@ -58,15 +56,6 @@ export function LoginForm({ defaultEmail = '', callbackUrl, initialError }: Logi
         return;
       }
 
-      const session = await getSession();
-
-      if (!session?.user?.role) {
-        setError('Signed in but could not load your account. Please try again.');
-        setSubmitting(false);
-        router.refresh();
-        return;
-      }
-
       const resolvedUrl = result?.url
         ? (() => {
             try {
@@ -78,15 +67,8 @@ export function LoginForm({ defaultEmail = '', callbackUrl, initialError }: Logi
           })()
         : callbackUrl;
 
-      const destination = getDashboardRouteForRole(session.user.role, resolvedUrl);
-
       setSubmitting(false);
-
-      if (destination !== pathname) {
-        router.replace(destination);
-        return;
-      }
-
+      router.replace(resolvedUrl);
       router.refresh();
     } catch (err) {
       console.error(err);

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,3 +1,4 @@
+import { unstable_noStore as noStore } from 'next/cache';
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 
@@ -7,6 +8,7 @@ import { LOGIN_ROUTE, getDashboardRouteForRole, type AppUserRole } from './route
 export const getAuthSession = () => getServerSession(authOptions);
 
 export const requireAuthSession = async () => {
+  noStore();
   const session = await getAuthSession();
 
   if (!session) {
@@ -17,6 +19,7 @@ export const requireAuthSession = async () => {
 };
 
 export const requireRole = async (roles: AppUserRole | AppUserRole[]) => {
+  noStore();
   const session = await requireAuthSession();
   const allowed = Array.isArray(roles) ? roles : [roles];
 


### PR DESCRIPTION
## Summary
- simplify the credential sign-in flow to redirect through the provided callback URL after successful authentication
- mark authenticated session helpers as non-cacheable and add middleware headers to block caching on role-protected routes
- keep middleware-driven redirects for admins and workers so manual URL access respects assigned roles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dea2e68728832eb39521f312d0e1e7